### PR TITLE
Add icons prop  to component Input

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     }
   },
   "dependencies": {
-    "@elephas/core": "^1.0.0-beta.13",
-    "@elephas/layout": "^1.0.0-beta.13",
+    "@elephas/core": "^1.0.0-beta.14",
+    "@elephas/layout": "^1.0.0-beta.14",
     "mime": "^2.4.6",
     "react": "^16.11.0",
     "react-dom": "^16.11.0"

--- a/src/packages/core/package.json
+++ b/src/packages/core/package.json
@@ -17,7 +17,7 @@
   "module": "elephas-react-core.esm.min.js",
   "types": "types/packages/core/src/index.d.ts",
   "peerDependencies": {
-    "@elephas/core": "^1.0.0-beta.13",
+    "@elephas/core": "^1.0.0-beta.14",
     "mime": "^2.4.6",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/src/packages/core/src/base-input/BaseInput.tsx
+++ b/src/packages/core/src/base-input/BaseInput.tsx
@@ -1,9 +1,9 @@
 import React, { cloneElement } from 'react';
 import classNames from 'classnames';
 
-import { BaseInputProps } from './types';
+import { BaseInputProps, HTMLAttributesComposite } from './types';
 
-export function BaseInput(props: BaseInputProps) {
+export function BaseInput<T extends HTMLAttributesComposite>(props: BaseInputProps<T>) {
   const {
     appearance = 'default',
     children,

--- a/src/packages/core/src/base-input/BaseInput.tsx
+++ b/src/packages/core/src/base-input/BaseInput.tsx
@@ -11,13 +11,8 @@ export function BaseInput<T extends HTMLAttributesComposite>(props: BaseInputPro
     error,
     hint,
     label,
-    name = '',
-    onBlur,
-    onChange,
-    onFocus,
-    onKeyDown,
-    value,
     width = '100%',
+    icons,
     ...rest
   } = props;
 
@@ -34,25 +29,24 @@ export function BaseInput<T extends HTMLAttributesComposite>(props: BaseInputPro
       {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
       <label className="_e_input__field">
         {
-          cloneElement(children, {
+          cloneElement<T>(children, {
             className: '_e_input__control',
             disabled: appearance === 'disabled',
-            name,
-            onChange,
-            onFocus,
-            onBlur,
-            onKeyDown,
             placeholder: ' ',
             readOnly: appearance === 'readonly',
-            value,
             ...rest,
           })
-        }
+         }
         <span className="_e_input__label">
           { label }
         </span>
         <span className="_e_input__background" />
         <span className="_e_input__line" />
+        { icons && (
+          <div className="_e_input__icon">
+            { icons }
+          </div>
+        )}
       </label>
       {
         hint

--- a/src/packages/core/src/base-input/types.ts
+++ b/src/packages/core/src/base-input/types.ts
@@ -2,12 +2,13 @@ import {
   InputHTMLAttributes,
   TextareaHTMLAttributes,
   ReactElement,
+  ReactNode,
 } from 'react';
 
 export type HTMLAttributesComposite =
     | InputHTMLAttributes<HTMLInputElement>
-    | TextareaHTMLAttributes<HTMLTextAreaElement>
-    | InputHTMLAttributes<HTMLSelectElement>;
+    | InputHTMLAttributes<HTMLSelectElement>
+    | TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 export type AbstractInput<T extends HTMLAttributesComposite> = T & {
   /**
@@ -30,6 +31,8 @@ export type AbstractInput<T extends HTMLAttributesComposite> = T & {
    * Hint message. Hidden when appearance is set to `error`.
    */
   hint?: string;
+
+  icons?: ReactNode,
 
   /**
    * Field label.

--- a/src/packages/core/src/base-input/types.ts
+++ b/src/packages/core/src/base-input/types.ts
@@ -1,15 +1,15 @@
 import {
-  ChangeEventHandler,
-  FocusEventHandler,
   InputHTMLAttributes,
-  KeyboardEventHandler,
   TextareaHTMLAttributes,
   ReactElement,
 } from 'react';
 
-export type HTMLAttributesComposite = InputHTMLAttributes<HTMLElement> | TextareaHTMLAttributes<HTMLElement>;
+export type HTMLAttributesComposite =
+    | InputHTMLAttributes<HTMLInputElement>
+    | TextareaHTMLAttributes<HTMLTextAreaElement>
+    | InputHTMLAttributes<HTMLSelectElement>;
 
-export type AbstractInput = {
+export type AbstractInput<T extends HTMLAttributesComposite> = T & {
   /**
    * Visual appearance.
    * @default default
@@ -37,43 +37,12 @@ export type AbstractInput = {
   label: string;
 
   /**
-   * Field name.
-   * @default ''
-   */
-  name?: string;
-
-  /**
-   * Blur handler.
-   */
-  onBlur?: FocusEventHandler<HTMLElement>;
-
-  /**
-   * Change handler.
-   */
-  onChange?: ChangeEventHandler<HTMLElement>;
-
-  /**
-   * Focus handler.
-   */
-  onFocus?: FocusEventHandler<HTMLElement>;
-
-  /**
-   * KeyDown handler.
-   */
-  onKeyDown?: KeyboardEventHandler<HTMLElement>;
-
-  /**
-   * Field value.
-   */
-  value?: string | string[] | number;
-
-  /**
    * Field width.
    * @default 100%
    */
   width?: '2' | '4' | '6' | '8' | '12' | '100%';
 };
 
-export interface BaseInputProps extends AbstractInput {
-  children: ReactElement<HTMLAttributesComposite>;
-}
+export type BaseInputProps<T extends HTMLAttributesComposite> = AbstractInput<T> & {
+  children: ReactElement<T>;
+};

--- a/src/packages/core/src/input/Input.tsx
+++ b/src/packages/core/src/input/Input.tsx
@@ -7,7 +7,6 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
   (props: InputProps, ref: Ref<HTMLInputElement>) => {
     const {
       defaultValue,
-      type = 'text',
       ...rest
     } = props;
 
@@ -15,7 +14,6 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       <BaseInput {...rest}>
         <input
           defaultValue={defaultValue}
-          type={type}
           ref={ref}
         />
       </BaseInput>

--- a/src/packages/core/src/input/types.ts
+++ b/src/packages/core/src/input/types.ts
@@ -1,14 +1,9 @@
+import { InputHTMLAttributes } from 'react';
 import { AbstractInput } from '../base-input/types';
 
-export interface InputProps extends AbstractInput {
+export type InputProps = AbstractInput<InputHTMLAttributes<HTMLInputElement>> & {
   /**
    * Default value for uncontrolled input.
    */
   defaultValue?: string;
-
-  /**
-   * Input type.
-   * @default text
-   */
-  type?: string;
-}
+};

--- a/src/packages/core/src/select/types.ts
+++ b/src/packages/core/src/select/types.ts
@@ -1,3 +1,4 @@
+import { InputHTMLAttributes } from 'react';
 import { AbstractInput } from '../base-input/types';
 
 type Option = {
@@ -12,7 +13,7 @@ type Option = {
   value: string;
 };
 
-export interface SelectProps extends AbstractInput {
+export type SelectProps = AbstractInput<InputHTMLAttributes<HTMLSelectElement>> & {
   /**
    * Default value for uncontrolled input.
    */
@@ -22,4 +23,4 @@ export interface SelectProps extends AbstractInput {
    * Select options.
    */
   options: Option[];
-}
+};

--- a/src/packages/core/src/textarea/types.ts
+++ b/src/packages/core/src/textarea/types.ts
@@ -1,14 +1,9 @@
+import { TextareaHTMLAttributes } from 'react';
 import { AbstractInput } from '../base-input/types';
 
-export interface TextareaProps extends AbstractInput {
+export type TextareaProps = AbstractInput<TextareaHTMLAttributes<HTMLTextAreaElement>> & {
   /**
    * Default value for uncontrolled input.
    */
   defaultValue?: string;
-
-  /**
-   * Textarea row attribute.
-   * @default 3
-   */
-  rows: number
-}
+};

--- a/src/packages/layout/package.json
+++ b/src/packages/layout/package.json
@@ -20,8 +20,8 @@
     "@elephas/react-core": "1.0.0-beta.6"
   },
   "peerDependencies": {
-    "@elephas/core": "^1.0.0-beta.13",
-    "@elephas/layout": "^1.0.0-beta.13",
+    "@elephas/core": "^1.0.0-beta.14",
+    "@elephas/layout": "^1.0.0-beta.14",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,17 +1243,17 @@
   resolved "https://registry.yarnpkg.com/@commitlint/types/-/types-9.1.1.tgz#d97ebc35d20eed6d8458361cbca5c7cb85d45184"
   integrity sha512-SXY8bCQ1qacJ8AUTUxjabY8G6OjSmMPLN9MBCzGaKOjpPNX6z8zbXTbk9oU3GHZLtcxweWLCi2n49IRS4iQlwg==
 
-"@elephas/core@1.0.0-beta.13", "@elephas/core@^1.0.0-beta.13":
-  version "1.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/@elephas/core/-/core-1.0.0-beta.13.tgz#1d254d113908719d85f311f877423b1ab17a1764"
-  integrity sha512-PMnUkGwjG11kA33Kz5MqDWhDMvCuXwReuHAmzo55CktHyfxngYjDKsRZorXUx0UVewaM7np3vbX6CGKiliNkNw==
+"@elephas/core@1.0.0-beta.14", "@elephas/core@^1.0.0-beta.14":
+  version "1.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@elephas/core/-/core-1.0.0-beta.14.tgz#a0d5ac8e08a00475805866bde2a45a10313d8597"
+  integrity sha512-n+7ME9v30ydKOrTVgGaFZ0BmW44/dlCSyXdTmKy6FMy/YYzNsvvv6OZMwtgE3Ofnx8QaBETWk24IIjRn/BzdEw==
 
-"@elephas/layout@^1.0.0-beta.13":
-  version "1.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/@elephas/layout/-/layout-1.0.0-beta.13.tgz#467c1fffd4ac6512d183afeae598f5a91a2c4d0d"
-  integrity sha512-VWJndfZHLetb6fkJ1sv0JnCtnHwjfk946ZN5Ydni5pqy9MqJ7dcphRiKWo39kUw9mN9Kvy1PKcknRuJ8Lw3ikQ==
+"@elephas/layout@^1.0.0-beta.14":
+  version "1.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@elephas/layout/-/layout-1.0.0-beta.14.tgz#08ae1b3a94d9240cdd49dc994ccb11e2793360e5"
+  integrity sha512-OwxsBeLFV9dYy0NVYjhlMrAmpToKk27heK6y5siLavp9xS0ULwrR6DKBwzTbNRn/1GMwCgN/SL5uleNwbevbUg==
   dependencies:
-    "@elephas/core" "1.0.0-beta.13"
+    "@elephas/core" "1.0.0-beta.14"
 
 "@emotion/cache@^10.0.27":
   version "10.0.29"


### PR DESCRIPTION
## Improve types inference

### Мотивация:

Из-за того, что раньше для `TextareaHTMLAttributes` и  всех `EventHandler`  был указан  тип `HTMLElement`

то для соответствующих `props` `types inference` работал неправильно, например

```ts
onChange={(event) => {}}

typeof event => ChangeEvent<HTMLElement> 
```  

что в свою очередь приводило к принудительному кастингу типов в  `eventHandler` на стороне разработчика использующего наш компонент  

```ts
onChange={(event: ChangeEvent<HTMLInputElement>) => {}}
```
 
так как  

```ts
error: Property 'value' does not exist on type 'EventTarget & HTMLElement'.
```

### Что я сделал:

расширил имеющиеся `types` и добавил `generic` для `types`  `AbstractInput` и `BaseInputProps`;

## Add icons props
 