### PR TITLE
Button improve types inference

### DIFF
--- a/src/packages/core/src/button/Button.tsx
+++ b/src/packages/core/src/button/Button.tsx
@@ -9,7 +9,6 @@ export function Button(props: ButtonProps) {
     disabled = false,
     children,
     className,
-    onClick,
     size = 'default',
     type = 'button',
     ...rest
@@ -29,7 +28,6 @@ export function Button(props: ButtonProps) {
     <button
       className={buttonClassNames}
       disabled={disabled}
-      onClick={onClick}
       // https://github.com/yannickcr/eslint-plugin-react/issues/1555
       // eslint-disable-next-line react/button-has-type
       type={type}

--- a/src/packages/core/src/button/types.ts
+++ b/src/packages/core/src/button/types.ts
@@ -1,7 +1,7 @@
-import { ReactNode, MouseEventHandler } from 'react';
+import { ButtonHTMLAttributes, PropsWithChildren } from 'react';
 import { CommonAttributes } from '../../../../common';
 
-export interface ButtonProps extends CommonAttributes {
+interface CustomProps extends CommonAttributes, ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * Visual appearance.
    * @default default
@@ -9,34 +9,15 @@ export interface ButtonProps extends CommonAttributes {
   appearance?: 'default' | 'danger' | 'primary';
 
   /**
-   * Button contents.
-   */
-  children: ReactNode;
-
-  /**
    * Additional CSS class.
    */
   className?: string;
-
-  /**
-   * Button disabled state.
-   */
-  disabled?: boolean;
-
-  /**
-   * Click handler.
-   */
-  onClick?: MouseEventHandler<HTMLButtonElement>
 
   /**
    * Button size.
    * @default default
    */
   size?: 'default' | 'large' | 'small';
-
-  /**
-   * Button type.
-   * @default button
-   */
-  type?: 'button' | 'reset' | 'submit';
 }
+
+export type ButtonProps = PropsWithChildren<CustomProps>;


### PR DESCRIPTION
## Мотивация

Текущей реализации компонента не поддерживала часть нативных атрибутов, таких как `value`, `onReset` и т.д.

## Решение

Базовый тип нашего компонента был расширен за счёт `ButtonHTMLAttributes<HTMLButtonElement>`               