### PR TITLE
Add @elephas/react-core to rollup globals

### DIFF
--- a/src/packages/layout/rollup.config.js
+++ b/src/packages/layout/rollup.config.js
@@ -17,6 +17,7 @@ const globals = {
   react: 'React',
   'react-dom': 'ReactDOM',
   mime: 'Mime',
+  '@elephas/react-core': 'ElephasReactCore',
 };
 
 const getOutputFileName = (name) => path.resolve(__dirname, './dist', name);


### PR DESCRIPTION
Release workflow fails with the error message shown below. Treating core package as a peer dependency, and adding it to `globals` should fix the problem.

```
$ yarn build:prepare && yarn build:rollup && yarn build:types
$ rm -rf dist && mkdir -p dist && cp package.json dist && cp ../../../LICENSE.md dist
$ ../../../node_modules/.bin/rollup -c ./rollup.config.js
./src/index.ts → dist/elephas-react-layout.umd.min.js, dist/elephas-react-layout.esm.min.js...
(!) Unresolved dependencies
https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
@elephas/react-core (imported by src/sidebar/SidebarHeading.tsx, src/sidebar/SidebarItem.tsx)
(!) Missing global variable name
Use output.globals to specify browser global variable names corresponding to external modules
@elephas/react-core (guessing 'reactCore')
created dist/elephas-react-layout.umd.min.js, dist/elephas-react-layout.esm.min.js in 2.1s
$ ../../../node_modules/.bin/tsc -p ./tsconfig.build.json
src/sidebar/SidebarHeading.tsx(3,25): error TS2307: Cannot find module '@elephas/react-core' or its corresponding type declarations.
src/sidebar/SidebarItem.tsx(3,25): error TS2307: Cannot find module '@elephas/react-core' or its corresponding type declarations.
error Command failed with exit code 2.
```