### PR TITLE
Move Snackbar countdown inside button

### DIFF
--- a/src/packages/core/src/snackbar/Snackbar.tsx
+++ b/src/packages/core/src/snackbar/Snackbar.tsx
@@ -44,12 +44,12 @@ export function Snackbar(props: SnackbarProps) {
     <div className={snackbarClassNames}>
       <div className="_e_snackbar__text">
         {message}
-        <span className="_e_snackbar__timer">
-          :
-          {autoHideDuration}
-        </span>
       </div>
-      <Button onClick={onClose} className="_e_snackbar__button _e_button">{buttonText}</Button>
+      <Button onClick={onClose} className="_e_snackbar__button _e_button">
+        {buttonText}
+        {' :'}
+        {autoHideDuration.toString().padStart(2, '0')}
+      </Button>
     </div>
   );
 }

--- a/src/packages/core/src/snackbar/SnackbarExample.tsx
+++ b/src/packages/core/src/snackbar/SnackbarExample.tsx
@@ -16,13 +16,13 @@ export function SnackbarExample() {
   return (
     <>
       <Button onClick={handleClick}>
-        Snackbar
+        Open Snackbar
       </Button>
       <Snackbar
         onClose={handleClose}
         isOpen={isOpen}
-        buttonText="Отменить"
-        message="Сохранить изменения"
+        buttonText="Cancel"
+        message="Changes saved."
       />
     </>
   );


### PR DESCRIPTION
This moves `Snackbar` countdown inside "Cancel" button according to recommendations from https://github.com/cft-group/elephas/pull/65

<img width="681" alt="image" src="https://user-images.githubusercontent.com/2337671/97546512-23a06080-19ff-11eb-8544-4b7adb6b2e19.png">
