### PR TITLE
CheckboxGroup & RadioGroup improvements

### DIFF
--- a/src/packages/core/src/checkbox-group/CheckboxGroup.stories.mdx
+++ b/src/packages/core/src/checkbox-group/CheckboxGroup.stories.mdx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { Meta, Description, Props, Preview, Story } from '@storybook/addon-docs/blocks';
+
+import { CheckboxGroup } from '.';
+
+<Meta title="Core/CheckboxGroup" component={CheckboxGroup} />
+
+# CheckboxGroup
+
+<Props of={CheckboxGroup} />
+
+<Preview>
+  <Story name="CheckboxGroup">
+  {
+    () => {
+      const [value, setValue] = useState([]);
+      return <CheckboxGroup
+          name="option1"
+          label="Options"
+          value={value}
+          onChange={event => setValue(value.includes(event.target.value) ? value.filter(el => el !== event.target.value) : [...value, event.target.value])}
+          options={[
+            { value: '1', title: 'option 1', description: 'option 1 description' },
+            { value: '2', title: 'option 2' },
+          ]}
+        />
+    }
+  }
+  </Story>
+</Preview>
+
+<Preview>
+  <Story name="readonly">
+  {
+    () => {
+      const [value, setValue] = useState(['1', '2']);
+      return <CheckboxGroup
+          name="option2"
+          label="Options"
+          readonly
+          value={value}
+          onChange={event => setValue(value.includes(event.target.value) ? value.filter(el => el !== event.target.value) : [...value, event.target.value])}
+          options={[
+            { value: '1', title: 'option 1' },
+            { value: '2', title: 'option 2' },
+          ]}
+        />
+    }
+  }
+  </Story>
+</Preview>
+
+<Preview>
+  <Story name="disabled">
+  {
+    () => {
+      const [value, setValue] = useState(['1']);
+      return <CheckboxGroup
+          name="option3"
+          label="Options"
+          disabled
+          value={value}
+          onChange={event => setValue(value.includes(event.target.value) ? value.filter(el => el !== event.target.value) : [...value, event.target.value])}
+          options={[
+            { value: '1', title: 'option 1' },
+            { value: '2', title: 'option 2' },
+          ]}
+        />
+    }
+  }
+  </Story>
+</Preview>

--- a/src/packages/core/src/checkbox-group/CheckboxGroup.test.tsx
+++ b/src/packages/core/src/checkbox-group/CheckboxGroup.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+
+import { CheckboxGroup } from './CheckboxGroup';
+import { CheckboxGroupProps } from './types';
+
+describe('<CheckboxGroup />', () => {
+  const props: CheckboxGroupProps = {
+    name: 'Options',
+    value: ['1'],
+    onChange: jest.fn(),
+    options: [
+      { value: '1', title: 'option 1' },
+      { value: '2', title: 'option 2' },
+    ],
+  };
+
+  it('should not fire onChange if CheckboxGroup is disabled', () => {
+    const onChange = jest.fn();
+    render(<CheckboxGroup {...props} disabled value={['1']} onChange={onChange} />);
+
+    const checkboxButton = screen.getByDisplayValue('2');
+
+    fireEvent.change(checkboxButton);
+
+    expect(onChange).toBeCalledTimes(0);
+  });
+
+  it('should fire change value with selected Checkbox value', () => {
+    const onChange = jest.fn();
+
+    render(<CheckboxGroup {...props} value={['1']} onChange={onChange} />);
+
+    const checkboxButton = screen.getByDisplayValue('2') as HTMLInputElement;
+
+    fireEvent.change(checkboxButton, { target: { value: '2' } });
+
+    expect(checkboxButton.value).toBe('2');
+  });
+});

--- a/src/packages/core/src/checkbox-group/CheckboxGroup.tsx
+++ b/src/packages/core/src/checkbox-group/CheckboxGroup.tsx
@@ -1,0 +1,55 @@
+import React, { ChangeEvent } from 'react';
+
+import { CheckboxGroupProps } from './types';
+import { Fieldset } from '../fieldset';
+import { Checkbox } from '../checkbox';
+
+export const CheckboxGroup = (props: CheckboxGroupProps) => {
+  const {
+    className,
+    id,
+    legend,
+    value,
+    name = '',
+    disabled = false,
+    readonly = false,
+    onChange,
+    options,
+    error,
+    hint,
+    ...rest
+  } = props;
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (!disabled && !readonly) {
+      onChange(event);
+    }
+  };
+
+  const renderOptions = options.map((option) => (
+    <Checkbox
+      key={option.value}
+      label={option.title}
+      description={option.description}
+      checked={value.includes(option.value)}
+      disabled={disabled}
+      readonly={readonly}
+      name={name}
+      value={option.value}
+      onChange={handleChange}
+    />
+  ));
+
+  return (
+    <Fieldset
+      className={className}
+      id={id}
+      legend={legend}
+      error={error}
+      hint={hint}
+      {...rest}
+    >
+      {renderOptions}
+    </Fieldset>
+  );
+};

--- a/src/packages/core/src/checkbox-group/index.ts
+++ b/src/packages/core/src/checkbox-group/index.ts
@@ -1,0 +1,1 @@
+export { CheckboxGroup } from './CheckboxGroup';

--- a/src/packages/core/src/checkbox-group/types.ts
+++ b/src/packages/core/src/checkbox-group/types.ts
@@ -1,0 +1,79 @@
+import { ChangeEventHandler } from 'react';
+import { CommonAttributes } from 'common';
+
+interface CheckboxGroupOption {
+  /**
+   * Checkbox description.
+   */
+  description?: string;
+
+  /**
+   * Checkbox option title.
+   */
+  title: string;
+
+  /**
+   * Checkbox option value.
+   */
+  value: string;
+}
+
+export interface CheckboxGroupProps extends CommonAttributes {
+  /**
+   * Additional CSS class.
+   */
+  className?: string;
+
+  /**
+   * Checkbox group disabled state.
+   * @default false
+   */
+  disabled?: boolean;
+
+  /**
+   * Error message.
+   */
+  error?: string;
+
+  /**
+   * Hint message. Hidden when `error` is not empty.
+   */
+  hint?: string;
+
+  /**
+   * Checkbox group id.
+   */
+  id?: string;
+
+  /**
+   * Checkbox group legend.
+   */
+  legend?: string;
+
+  /**
+   * Checkbox group name.
+   * @default ''
+   */
+  name: string;
+
+  /**
+   * Change handler.
+   */
+  onChange: ChangeEventHandler<HTMLInputElement>;
+
+  /**
+   * Checkbox group options.
+   */
+  options: CheckboxGroupOption[];
+
+  /**
+   * Checkbox group readonly state.
+   * @default false
+   */
+  readonly?: boolean;
+
+  /**
+   * Values of selected options.
+   */
+  value: string[];
+}

--- a/src/packages/core/src/index.ts
+++ b/src/packages/core/src/index.ts
@@ -4,6 +4,7 @@ import { Banner } from './banner';
 import { Breadcrumbs, PassiveBreadcrumb } from './breadcrumbs';
 import { Button } from './button';
 import { Checkbox } from './checkbox';
+import { CheckboxGroup } from './checkbox-group';
 import { DataList } from './datalist';
 import { Fieldset } from './fieldset';
 import { Info } from './info';
@@ -27,6 +28,7 @@ export {
   PassiveBreadcrumb,
   Button,
   Checkbox,
+  CheckboxGroup,
   DataList,
   Fieldset,
   Info,

--- a/src/packages/core/src/radio-group/RadioGroup.stories.mdx
+++ b/src/packages/core/src/radio-group/RadioGroup.stories.mdx
@@ -19,6 +19,8 @@ import { RadioGroup } from '.';
           label="Options"
           value={value}
           onChange={event => setValue(event.target.value)}
+          hint="Group hint"
+          legend="Group legend"
           options={[
             { value: '1', title: 'option 1', description: 'option 1 description' },
             { value: '2', title: 'option 2' },

--- a/src/packages/core/src/radio-group/RadioGroup.stories.mdx
+++ b/src/packages/core/src/radio-group/RadioGroup.stories.mdx
@@ -15,12 +15,12 @@ import { RadioGroup } from '.';
     () => {
       const [value, setValue] = useState('1');
       return <RadioGroup
-          name="option"
+          name="option1"
           label="Options"
           value={value}
           onChange={event => setValue(event.target.value)}
           options={[
-            { value: '1', title: 'option 1' },
+            { value: '1', title: 'option 1', description: 'option 1 description' },
             { value: '2', title: 'option 2' },
           ]}
         />
@@ -35,7 +35,7 @@ import { RadioGroup } from '.';
     () => {
       const [value, setValue] = useState('1');
       return <RadioGroup
-          name="option"
+          name="option2"
           label="Options"
           readonly
           value={value}
@@ -56,7 +56,7 @@ import { RadioGroup } from '.';
     () => {
       const [value, setValue] = useState('1');
       return <RadioGroup
-          name="option"
+          name="option3"
           label="Options"
           disabled
           value={value}

--- a/src/packages/core/src/radio-group/RadioGroup.tsx
+++ b/src/packages/core/src/radio-group/RadioGroup.tsx
@@ -15,6 +15,8 @@ export const RadioGroup = (props: RadioGroupProps) => {
     readonly = false,
     onChange,
     options,
+    error,
+    hint,
     ...rest
   } = props;
 
@@ -41,7 +43,14 @@ export const RadioGroup = (props: RadioGroupProps) => {
   ));
 
   return (
-    <Fieldset {...rest} className={className} id={id} legend={legend}>
+    <Fieldset
+      className={className}
+      id={id}
+      legend={legend}
+      error={error}
+      hint={hint}
+      {...rest}
+    >
       {renderOptions}
     </Fieldset>
   );

--- a/src/packages/core/src/radio-group/RadioGroup.tsx
+++ b/src/packages/core/src/radio-group/RadioGroup.tsx
@@ -30,6 +30,7 @@ export const RadioGroup = (props: RadioGroupProps) => {
     <Radio
       key={option.value}
       label={option.title}
+      description={option.description}
       checked={option.value === value}
       disabled={disabled}
       readonly={readonly}

--- a/src/packages/core/src/radio-group/types.ts
+++ b/src/packages/core/src/radio-group/types.ts
@@ -31,6 +31,16 @@ export interface RadioGroupProps extends CommonAttributes {
   disabled?: boolean;
 
   /**
+   * Error message.
+   */
+  error?: string;
+
+  /**
+   * Hint message. Hidden when `error` is not empty.
+   */
+  hint?: string;
+
+  /**
    * Radio group id.
    */
   id?: string;

--- a/src/packages/core/src/radio-group/types.ts
+++ b/src/packages/core/src/radio-group/types.ts
@@ -3,6 +3,11 @@ import { CommonAttributes } from 'common';
 
 interface RadioGroupOption {
   /**
+   * Radio description.
+   */
+  description?: string;
+
+  /**
    * Radio option title.
    */
   title: string;


### PR DESCRIPTION
### Что сделал

1. Добавил поля `error`, `hint` к компоненту `RadioGroup`.
1. Добавил возможность передавать поле `description` к радио-кнопкам внутри `RadioGroup`.
1. Добавил компонент `CheckboxGroup` по аналогии с `RadioGroup`, чтобы иметь аналогичную логику взаимодействия при конструировании сложных форм.

### Что еще хочется

1. Расширить возможности опций внутри `RadioGroup` и `CheckboxGroup`: передавать индивидуально `disabled` и (только у чекбоксов) `name` опциям.
1. Добавить `defaultValue` для `RadioGroup` и `CheckboxGroup`.
1. Добавить возможность передавать `ReactNode` в `label` чекбоксам и радио.