### PR TITLE
fix(radio-group, checkbox-group): add index to option keys

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,6 @@ module.exports = {
     'import/prefer-default-export': 'off',
     'react/require-default-props': 'off',
     'typescript-sort-keys/interface': 'error',
-    'react/no-array-index-key': 'off'
   },
   settings: {
     react: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
     'import/prefer-default-export': 'off',
     'react/require-default-props': 'off',
     'typescript-sort-keys/interface': 'error',
+    'react/no-array-index-key': 'off'
   },
   settings: {
     react: {

--- a/src/packages/core/src/checkbox-group/CheckboxGroup.tsx
+++ b/src/packages/core/src/checkbox-group/CheckboxGroup.tsx
@@ -26,9 +26,9 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
     }
   };
 
-  const renderOptions = options.map((option) => (
+  const renderOptions = options.map((option, index) => (
     <Checkbox
-      key={option.value}
+      key={`${option.value}-${index}`}
       label={option.title}
       description={option.description}
       checked={value.includes(option.value)}

--- a/src/packages/core/src/checkbox-group/CheckboxGroup.tsx
+++ b/src/packages/core/src/checkbox-group/CheckboxGroup.tsx
@@ -28,6 +28,7 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
 
   const renderOptions = options.map((option, index) => (
     <Checkbox
+      // eslint-disable-next-line react/no-array-index-key
       key={`${option.value}-${index}`}
       label={option.title}
       description={option.description}

--- a/src/packages/core/src/datalist/DataList.tsx
+++ b/src/packages/core/src/datalist/DataList.tsx
@@ -28,6 +28,7 @@ export function DataList(props: DataListProps) {
         return (
           <div
             className={lineClassNames}
+            // eslint-disable-next-line react/no-array-index-key
             key={`${item.title}-${index}`}
           >
             <div className="_e_datalist__title" style={{ flexBasis: titleWidth }}>{ item.title }</div>

--- a/src/packages/core/src/datalist/DataList.tsx
+++ b/src/packages/core/src/datalist/DataList.tsx
@@ -28,8 +28,7 @@ export function DataList(props: DataListProps) {
         return (
           <div
             className={lineClassNames}
-            /* eslint-disable-next-line react/no-array-index-key */
-            key={`${index}-${item.title}`}
+            key={`${item.title}-${index}`}
           >
             <div className="_e_datalist__title" style={{ flexBasis: titleWidth }}>{ item.title }</div>
             <div className="_e_datalist__value">{ item.value }</div>

--- a/src/packages/core/src/radio-group/RadioGroup.tsx
+++ b/src/packages/core/src/radio-group/RadioGroup.tsx
@@ -30,6 +30,7 @@ export const RadioGroup = (props: RadioGroupProps) => {
 
   const renderOptions = options.map((option, index) => (
     <Radio
+      // eslint-disable-next-line react/no-array-index-key
       key={`${option.value}-${index}`}
       label={option.title}
       description={option.description}

--- a/src/packages/core/src/radio-group/RadioGroup.tsx
+++ b/src/packages/core/src/radio-group/RadioGroup.tsx
@@ -28,9 +28,9 @@ export const RadioGroup = (props: RadioGroupProps) => {
     }
   };
 
-  const renderOptions = options.map((option) => (
+  const renderOptions = options.map((option, index) => (
     <Radio
-      key={option.value}
+      key={`${option.value}-${index}`}
       label={option.title}
       description={option.description}
       checked={option.value === value}
@@ -44,6 +44,7 @@ export const RadioGroup = (props: RadioGroupProps) => {
 
   return (
     <Fieldset
+      role="radiogroup"
       className={className}
       id={id}
       legend={legend}


### PR DESCRIPTION
Добавила более специфичный ключ отображаемым опциям. Сейчас для отрисовки опций в RadioGroup и CheckboxGroup используется `key={option.value}`. В теории пользователь может передать любые values, в том числе и одинаковые, поэтому для большей специфичности добавляется index.